### PR TITLE
Fix compressed arc parsing

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -9,7 +9,6 @@ use fancy_slice::FancySlice;
 
 pub fn arc(data: FancySlice, wii_memory: &WiiMemory, item: bool) -> Arc {
     // read the main header
-    let num_sub_headers = data.u16_be(6);
     let tag = util::parse_tag(data.relative_slice(0..3));
     let decompressed;
     let data = if tag == "ARC" {
@@ -20,6 +19,7 @@ pub fn arc(data: FancySlice, wii_memory: &WiiMemory, item: bool) -> Arc {
         decompressed = decompress(data);
         FancySlice::new(&decompressed)
     };
+    let num_sub_headers = data.u16_be(6);
 
     let name = data.str(0x10).unwrap().to_string();
 
@@ -81,11 +81,11 @@ impl Arc {
         let mut output = Vec::with_capacity(1024 * 1024); // Preallocate 1MB, we will likely need more, but dont want to overdo it as we have arcs in arcs.
 
         // create arc header
-        output.extend("ARC".chars().map(|x| x as u8));
+        output.extend("ARC".as_bytes());
         output.extend([0x00, 0x01, 0x01]); // TODO: ??
         output.extend(u16::to_be_bytes(self.children.len() as u16));
         output.extend([0x00; 8]);
-        output.extend(self.name.chars().map(|x| x as u8));
+        output.extend(self.name.as_bytes());
         while output.len() < ARC_HEADER_SIZE {
             output.push(0x00);
         }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -4,6 +4,7 @@ use fancy_slice::FancySlice;
 enum CompressionType {
     None,
     LZ77,
+    // This appears to be a custom implementation of LZ77
     ExtendedLZ77,
 }
 
@@ -30,7 +31,6 @@ pub fn decompress(bytes: FancySlice) -> Vec<u8> {
     };
     match compression_type {
         CompressionType::ExtendedLZ77 => {
-            // TODO: not quite sure where to start it
             decompress_lz77_extended(bytes.relative_slice(4..), &mut output);
         }
         other => panic!("Support for compression type {other:?} is not yet implemented"),


### PR DESCRIPTION
We were attempting to read the number of sub headers from the compressed data instead of the decompressed data.