### PR TITLE
Fix on browsers without wgpu (better)

### DIFF
--- a/src/renderer/app/mod.rs
+++ b/src/renderer/app/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::mpsc::{channel, Sender};
 use std::sync::Arc;
 
+use wgpu::InstanceDescriptor;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{EventLoop, EventLoopWindowTarget};
 use winit::window::Window;
@@ -73,7 +74,8 @@ impl App {
         let input = WinitInputHelper::new();
         let size = window.inner_size();
 
-        let instance = wgpu::Instance::default();
+        let instance =
+            wgpu::util::new_instance_with_webgpu_detection(InstanceDescriptor::default()).await;
         let surface = instance.create_surface(window.clone()).unwrap();
         let wgpu_state = WgpuState::new(
             instance,


### PR DESCRIPTION
Alternative fix to https://github.com/rukai/brawllib_rs/pull/14

This approach allows webgpu to be used with a fallback to webgl, enabled by https://github.com/gfx-rs/wgpu/pull/6371